### PR TITLE
Docs: Orthographic corrections.

### DIFF
--- a/Estructuras_de_Control.ipynb
+++ b/Estructuras_de_Control.ipynb
@@ -135,7 +135,7 @@
             "source": [
                 "\n",
                 "#### Operador de comparación mayor y menor que:\n",
-                "Tenemos múltiples operadores de comparación de órden, o comúnmente conocidos por desigualdades (en dicho caso, se llama a las comparaciones anteriores no-igualdades). Estas son:\n",
+                "Tenemos múltiples operadores de comparación de orden, o comúnmente conocidos por desigualdades (en dicho caso, se llama a las comparaciones anteriores no-igualdades). Estas son:\n",
                 "\n"
             ],
             "metadata": {}
@@ -380,7 +380,7 @@
             "cell_type": "markdown",
             "source": [
                 "\n",
-                "Finalmente, la última expresión se evalúa de izquierda a derecha. Aunque es útil saber la manera en que Julia ejecuta los operadores lógicos, a menudo se prefiere utilizar los paréntesis para eliminar las ambiguedades, permite que exista más legibilidad en el código.\n",
+                "Finalmente, la última expresión se evalúa de izquierda a derecha. Aunque es útil saber la manera en que Julia ejecuta los operadores lógicos, a menudo se prefiere utilizar los paréntesis para eliminar las ambigüedades, permite que exista más legibilidad en el código.\n",
                 "\n"
             ],
             "metadata": {}
@@ -504,7 +504,7 @@
             "cell_type": "markdown",
             "source": [
                 "\n",
-                "Los keywords `begin` y `end` conforman delimitadores para un bloque de código, considerandolo como una expresión. Incluso, el bloque de código puede ser asignado a una variable. Su principal uso consiste en evaluar varias expresiones encadenadas, retornando el valor de la última subexpresión.\n",
+                "Los keywords `begin` y `end` conforman delimitadores para un bloque de código, considerándolo como una expresión. Incluso, el bloque de código puede ser asignado a una variable. Su principal uso consiste en evaluar varias expresiones encadenadas, retornando el valor de la última subexpresión.\n",
                 "\n"
             ],
             "metadata": {}
@@ -537,7 +537,7 @@
             "cell_type": "markdown",
             "source": [
                 "\n",
-                "La función `testtriangle` respresenta un test de comprobación para saber si dada una terna de números, estos pueden representar las longitudes de los lados de un triángulo. \n",
+                "La función `testtriangle` representa un test de comprobación para saber si dada una terna de números, estos pueden representar las longitudes de los lados de un triángulo. \n",
                 "\n"
             ],
             "metadata": {}
@@ -574,7 +574,7 @@
             "cell_type": "markdown",
             "source": [
                 "\n",
-                "En el dessarrollo de la función se implementa la estructura de control `if`, donde si en efecto se cumple el criterio que en un triángulo la longitud de cada lado debe ser menor que la suma de los otros dos lados, se imprime la oración 'Las longitudes dadas representan los lados de un triángulo', en caso contrario se imprime 'Las longitudes dadas no representan los lados de un triángulo'.\n",
+                "En el desarrollo de la función se implementa la estructura de control `if`, donde si en efecto se cumple el criterio que en un triángulo la longitud de cada lado debe ser menor que la suma de los otros dos lados, se imprime la oración 'Las longitudes dadas representan los lados de un triángulo', en caso contrario se imprime 'Las longitudes dadas no representan los lados de un triángulo'.\n",
                 "\n",
                 "El bloque de código alternativo, `else`, es opcional, por ello puede prescindirse de dicho bloque si en el problema no se considera necesario.\n",
                 "\n"
@@ -710,9 +710,9 @@
             "source": [
                 "\n",
                 "**NOTAS:**\n",
-                "+ Las estructuras de control if no introducen un nuevo ámbito local, significa que se puede declarar una nueva variable en la estructura y  utilizarla fuera de este. Sin embargo, debe usarse con cuidado ya que puede introducir errores de sitaxis.\n",
+                "+ Las estructuras de control if no introducen un nuevo ámbito local, significa que se puede declarar una nueva variable en la estructura y  utilizarla fuera de este. Sin embargo, debe usarse con cuidado ya que puede introducir errores de sintaxis.\n",
                 "+ Devuelve el valor de la última expresión ejecutada en la estructura.\n",
-                "+ Los únicos valores aceptados en la condicional son los del tipo booleano. Significa que, a diferecia de otros lenguajes, no se permiten el uso de `0` o `1` en la condición.\n",
+                "+ Los únicos valores aceptados en la condicional son los del tipo booleano. Significa que, a diferencia de otros lenguajes, no se permiten el uso de `0` o `1` en la condición.\n",
                 "\n"
             ],
             "metadata": {}
@@ -776,7 +776,7 @@
             "cell_type": "markdown",
             "source": [
                 "\n",
-                "Las posibilidades con el paquete mencionados son varias, este guía la macro bajo la política de primera coinicidencia y se pueden establecer comparaciones entre distintos tipos de datos, además, coincidencia profunda con matrices. Puede encontrar mayor información en la [documentación del paquete Match.jl](https://kmsquire.github.io/Match.jl/latest/)\n",
+                "Las posibilidades con el paquete mencionados son varias, este guía la macro bajo la política de primera coincidencia y se pueden establecer comparaciones entre distintos tipos de datos, además, coincidencia profunda con matrices. Puede encontrar mayor información en la [documentación del paquete Match.jl](https://kmsquire.github.io/Match.jl/latest/)\n",
                 "\n"
             ],
             "metadata": {}
@@ -1021,7 +1021,7 @@
             "cell_type": "markdown",
             "source": [
                 "\n",
-                "**NOTA:** Para conocer más detalles acerca de las estructura de control en Julia puede consultar la sección [Control Flow](https://docs.julialang.org/en/v1/manual/control-flow/##Control-Flow) del maual de Julia.\n",
+                "**NOTA:** Para conocer más detalles acerca de las estructura de control en Julia puede consultar la sección [Control Flow](https://docs.julialang.org/en/v1/manual/control-flow/##Control-Flow) del manual de Julia.\n",
                 "\n"
             ],
             "metadata": {}


### PR DESCRIPTION
Hola, realice algunas correcciones ortográficas a las siguientes palabras:

órden -> orden.
ambiguedades -> ambigüedades.
considerandolo -> considerándolo.
respresenta -> representa.
dessarrollo -> desarrollo.
sitaxis -> sintaxis.
diferecia -> diferencia.  
coinicidencia -> coincidencia.
maual -> manual.