### PR TITLE
Docs: Orthographic corrections.

### DIFF
--- a/Estructuras_de_Datos.ipynb
+++ b/Estructuras_de_Datos.ipynb
@@ -12,7 +12,7 @@
             "source": [
                 "\n",
                 "## Estructuras de Datos\n",
-                "Las estructurtas de datos son formatos especiales de datos que permiten guardar, organizar y manipular información. En particular, cada estructura especifica la forma en la cual se pueden realizar operaciones sobre los datos que contiene y a la vez sobre qué tipo de datos trabajan. \n",
+                "Las estructuras de datos son formatos especiales de datos que permiten guardar, organizar y manipular información. En particular, cada estructura especifica la forma en la cual se pueden realizar operaciones sobre los datos que contiene y a la vez sobre qué tipo de datos trabajan. \n",
                 "\n",
                 "Las estructuras de datos ocultan al programador la manera en que se maneja la memoria y la gestionan de forma eficiente, por ende genera eficiencia en los algoritmos que los implementan. \n",
                 "\n",
@@ -31,7 +31,7 @@
                 "\n",
                 "`(:)(start,[step],stop)`\n",
                 "\n",
-                "Esta estructura permite crear secuencias de números, desde un número dado (`start` ) hasta otro (`stop`) con un tamaño de paso (`[step]`) que puede ser inidicado de forma opcional. \n",
+                "Esta estructura permite crear secuencias de números, desde un número dado (`start` ) hasta otro (`stop`) con un tamaño de paso (`[step]`) que puede ser indicado de forma opcional. \n",
                 "\n"
             ],
             "metadata": {}
@@ -210,7 +210,7 @@
                 "\n",
                 "En las inicializaciones anteriores el array acepta cualquier tipo de valor, pues su definición contempla elementos con el supertipo `Any` (en el caso de `array₂` se define de forma explícita y en el de `array₃` de forma implícita).\n",
                 "\n",
-                "Pueden existir casos en que el array solo deba contener elementos de un número limitado de tipos, en tales casos la declaración del tipo del array puede ser decalarado mediante `Union`, por ejemplo: `Array{Union{Int64,Float64,String},2}`. En el ejemplo el array solo podrá contener elementos del tipo: `Int64`, `Float64` o `String`.\n",
+                "Pueden existir casos en que el array solo deba contener elementos de un número limitado de tipos, en tales casos la declaración del tipo del array puede ser declarado mediante `Union`, por ejemplo: `Array{Union{Int64,Float64,String},2}`. En el ejemplo el array solo podrá contener elementos del tipo: `Int64`, `Float64` o `String`.\n",
                 "\n"
             ],
             "metadata": {}
@@ -241,7 +241,7 @@
             "cell_type": "markdown",
             "source": [
                 "\n",
-                "Los arrays anteriores están vacios, pero solo aceptan elementos que son del tipo `Float64` o que pueden ser promovidos a ese tipo (por ejemplo Int64 puede ser convertido a Float64).\n",
+                "Los arrays anteriores están vacíos, pero solo aceptan elementos que son del tipo `Float64` o que pueden ser promovidos a ese tipo (por ejemplo Int64 puede ser convertido a Float64).\n",
                 "\n"
             ],
             "metadata": {}
@@ -607,7 +607,7 @@
             "cell_type": "markdown",
             "source": [
                 "\n",
-                "Con el símbolo `:` se indica que todos los elementos de una dimensión del array deben ser extraidos; en el caso del array de una dimensión, todos los elementos del mismo.\n",
+                "Con el símbolo `:` se indica que todos los elementos de una dimensión del array deben ser extraídos; en el caso del array de una dimensión, todos los elementos del mismo.\n",
                 "\n"
             ],
             "metadata": {}
@@ -680,7 +680,7 @@
             "cell_type": "markdown",
             "source": [
                 "\n",
-                "Ello indica que Julia almacena los elementos del array de forma concecutiva por columnas. Por ende, si el array se recorre por filas se tendrán que hacer cálculos adicionales llevando un costo de tiempo; por esa razón el costo por acceder a un array por columnas es menor que si se hiciera por filas.\n",
+                "Ello indica que Julia almacena los elementos del array de forma consecutiva por columnas. Por ende, si el array se recorre por filas se tendrán que hacer cálculos adicionales llevando un costo de tiempo; por esa razón el costo por acceder a un array por columnas es menor que si se hiciera por filas.\n",
                 "\n"
             ],
             "metadata": {}
@@ -1014,7 +1014,7 @@
             "cell_type": "markdown",
             "source": [
                 "\n",
-                "Para que `splice!` funcione de la manera mostrada anteriormente, es necesario que el índice de los elementos donde se desea insertaer se indiquen de la forma `n:n-1`.\n",
+                "Para que `splice!` funcione de la manera mostrada anteriormente, es necesario que el índice de los elementos donde se desea insertar se indiquen de la forma `n:n-1`.\n",
                 "\n"
             ],
             "metadata": {}
@@ -1218,7 +1218,7 @@
             "cell_type": "markdown",
             "source": [
                 "\n",
-                "**NOTA:** Más funciones e información acerca de los arrays en Julia puede encontrarlo en el manual en la seción [Multi-dimensional Arrays](https://docs.julialang.org/en/v1/base/collections/##Base.maximum)\n",
+                "**NOTA:** Más funciones e información acerca de los arrays en Julia puede encontrarlo en el manual en la sección [Multi-dimensional Arrays](https://docs.julialang.org/en/v1/base/collections/##Base.maximum)\n",
                 "\n"
             ],
             "metadata": {}
@@ -1368,7 +1368,7 @@
                 "\n",
                 "### Tuplas\n",
                 "\n",
-                "Las tuplas (`Tuples`) son listas, pero a diferencia de los arrays son inmutables. Lo anterior quiere decir que una vez creada la tupla esta no puede ser: modificada, eliminada o sobreescrita, como sí sucede con los arrays. Al igual que los arrays, las tuplas pueden contener diferentes tipos de datos.\n",
+                "Las tuplas (`Tuples`) son listas, pero a diferencia de los arrays son inmutables. Lo anterior quiere decir que una vez creada la tupla esta no puede ser: modificada, eliminada o sobrescrita, como sí sucede con los arrays. Al igual que los arrays, las tuplas pueden contener diferentes tipos de datos.\n",
                 "\n",
                 "Para crear una tupla, los elementos de esta se encierran entre `()`. Se accede a los elementos de las tuplas de la misma forma en que se acceden a los elementos de un array.\n",
                 "\n"
@@ -1695,7 +1695,7 @@
             "cell_type": "markdown",
             "source": [
                 "\n",
-                "Las claves de un diccionario pueden obtenerse uando el método `keys`, el cual retorna un iterador. Se puede utilizar el método collect para transformarlo en un array.\n",
+                "Las claves de un diccionario pueden obtenerse usando el método `keys`, el cual retorna un iterador. Se puede utilizar el método collect para transformarlo en un array.\n",
                 "\n"
             ],
             "metadata": {}
@@ -1759,7 +1759,7 @@
                 "\n",
                 "#### Tipos de datos y los diccionarios\n",
                 "\n",
-                "En los diccionarios mostrados, el tipo de dato para la clave y los valores podian ser de diferentes tipos. La definición del diccionario es la siguiente: \n",
+                "En los diccionarios mostrados, el tipo de dato para la clave y los valores podían ser de diferentes tipos. La definición del diccionario es la siguiente: \n",
                 "\n"
             ],
             "metadata": {}
@@ -1781,7 +1781,7 @@
                 "\n",
                 "Como se observa `Dict{Any,Any}` indica que el tipo de dato para la clave es `Any` y para el valor es `Any`.\n",
                 "\n",
-                "Puede crearse un dicconario que restrinja el tipo de datos para la clave y valor, de esta manera puede crearse una estructura más compleja.\n",
+                "Puede crearse un diccionario que restrinja el tipo de datos para la clave y valor, de esta manera puede crearse una estructura más compleja.\n",
                 "\n"
             ],
             "metadata": {}
@@ -1975,7 +1975,7 @@
             "cell_type": "markdown",
             "source": [
                 "\n",
-                "Con el método `union` los conjuntos pueden fusionarse, retornando el conjunto resultante. Es decir, un conjunto cuyo elementos se ecuentra en cualquiera de los conjuntos.\n",
+                "Con el método `union` los conjuntos pueden fusionarse, retornando el conjunto resultante. Es decir, un conjunto cuyo elementos se encuentra en cualquiera de los conjuntos.\n",
                 "\n"
             ],
             "metadata": {}
@@ -2018,7 +2018,7 @@
             "cell_type": "markdown",
             "source": [
                 "\n",
-                "Con el método `intersect` se obtiene la interseción de los conjuntos, es decir, devuelve un conjunto cuyos elementos se encuentra en ambos conjuntos.\n",
+                "Con el método `intersect` se obtiene la intercesión de los conjuntos, es decir, devuelve un conjunto cuyos elementos se encuentra en ambos conjuntos.\n",
                 "\n"
             ],
             "metadata": {}
@@ -2092,7 +2092,7 @@
             "source": [
                 "\n",
                 "### List Comprehensions\n",
-                "Es un forma poderosa de crear listas o array, que también ha sido implementado en otros lenguages de programación.  Tiene la peculiaridad de definir los elementos del array de manera similar a la notación constructiva en matemática. Tiene la siguiente sintaxis:\n",
+                "Es un forma poderosa de crear listas o array, que también ha sido implementado en otros lenguajes de programación.  Tiene la peculiaridad de definir los elementos del array de manera similar a la notación constructiva en matemática. Tiene la siguiente sintaxis:\n",
                 "\n",
                 "`[ expresión for elemento ∈ colección]`\n",
                 "\n",


### PR DESCRIPTION
Hola, realice algunas correcciones ortográficas a las siguientes palabras:

estructurtas -> estructuras.
inidicado -> indicado.
decalarado -> declarado.
vacios -> vacíos.
extraidos -> extraídos.
concecutiva -> consecutiva.
insertaer -> insertar.
seción -> sección.
sobreescrita -> sobrescrita.
uando -> usando.
podian -> podían
dicconario -> diccionario.
ecuentra -> encuentra.
interseción -> intercesión.
lenguages -> lenguajes.